### PR TITLE
Added an 'unscrollbar' method.

### DIFF
--- a/jquery.scroll.js
+++ b/jquery.scroll.js
@@ -152,7 +152,9 @@ Changelog:
         //
         repaint: function(){
             return this.each(function(){
-                this.scrollbar.repaint();
+                if(this.scrollbar) {
+                  this.scrollbar.repaint();
+                }
             });
         },
 

--- a/jquery.scroll.js
+++ b/jquery.scroll.js
@@ -173,6 +173,19 @@ Changelog:
             return this.each(function(){
                 this.scrollbar.scrollto(to);
             });
+        },
+        
+        // Remove the scrollbar (and the generated HTML elements).
+        //
+        // usage:
+        //   $('selector').scrollbar("unscrollbar");
+        //
+        unscrollbar: function() {
+          return this.each(function() {
+            if(this.scrollbar) {
+              this.scrollbar.unscrollbar();
+            }
+          });
         }
     }
 
@@ -475,6 +488,16 @@ Changelog:
             this.handle.top = distance;
             this.setHandlePosition();
             this.setContentPosition();
+        },
+        
+        //
+        // Remove scrollbar dom elements
+        //
+        unscrollbar: function() {
+          var holder = this.container.find('.scrollbar-pane').find('*');
+          this.container.empty();
+          this.container.append(holder);
+          this.container.attr('style','');
         },
 
 


### PR DESCRIPTION
Hey there. I've been using your plugin on a project (and loving it) but I wanted a way to remove the scrollbar when there were no more elements in my container.  Here is my way of doing that (minus tests, sorry).

Also, I know that the method name sucks.
