### PR TITLE
unscrollbar was deleting text and doubling content

### DIFF
--- a/jquery.scroll.js
+++ b/jquery.scroll.js
@@ -184,6 +184,7 @@ Changelog:
           return this.each(function() {
             if(this.scrollbar) {
               this.scrollbar.unscrollbar();
+			  this.scrollbar = null;
             }
           });
         }

--- a/jquery.scroll.js
+++ b/jquery.scroll.js
@@ -494,7 +494,7 @@ Changelog:
         // Remove scrollbar dom elements
         //
         unscrollbar: function() {
-          var holder = this.container.find('.scrollbar-pane').find('*');
+          var holder = this.container.find('.scrollbar-pane').contents();
           this.container.empty();
           this.container.append(holder);
           this.container.attr('style','');

--- a/jquery.scroll.js
+++ b/jquery.scroll.js
@@ -495,9 +495,9 @@ Changelog:
         // Remove scrollbar dom elements
         //
         unscrollbar: function() {
-          var holder = this.container.find('.scrollbar-pane:first');
-          this.container.children().not('.scrollbar-pane').remove();
-          holder.replaceWith(holder.contents());
+          var holder = this.container.find('.scrollbar-pane:first').contents().clone(true);
+          this.container.empty();
+          this.container.append(holder);
           this.container.attr('style','');
         },
 

--- a/jquery.scroll.js
+++ b/jquery.scroll.js
@@ -495,9 +495,9 @@ Changelog:
         // Remove scrollbar dom elements
         //
         unscrollbar: function() {
-          var holder = this.container.find('.scrollbar-pane:first').contents();
-          this.container.empty();
-          this.container.append(holder);
+          var holder = this.container.find('.scrollbar-pane:first');
+          this.container.children().not('.scrollbar-pane').remove();
+          holder.replaceWith(holder.contents());
           this.container.attr('style','');
         },
 

--- a/jquery.scroll.js
+++ b/jquery.scroll.js
@@ -495,7 +495,7 @@ Changelog:
         // Remove scrollbar dom elements
         //
         unscrollbar: function() {
-          var holder = this.container.find('.scrollbar-pane :first').contents();
+          var holder = this.container.find('.scrollbar-pane:first').contents();
           this.container.empty();
           this.container.append(holder);
           this.container.attr('style','');

--- a/jquery.scroll.js
+++ b/jquery.scroll.js
@@ -495,7 +495,7 @@ Changelog:
         // Remove scrollbar dom elements
         //
         unscrollbar: function() {
-          var holder = this.container.find('.scrollbar-pane').contents();
+          var holder = this.container.find('.scrollbar-pane :first').contents();
           this.container.empty();
           this.container.append(holder);
           this.container.attr('style','');


### PR DESCRIPTION
The unscrollbar function wasn't working correctly. It fetched everything except text nodes, but including children of children. So all text was missing while other elements where doubled.
