### PR TITLE
Cannot call method 'scrollto' of undefined

### DIFF
--- a/jquery.scroll.js
+++ b/jquery.scroll.js
@@ -171,10 +171,12 @@ Changelog:
         //
         scrollto: function(to){
             return this.each(function(){
-                this.scrollbar.scrollto(to);
+                if(this.scrollbar) {
+                    this.scrollbar.scrollto(to);
+                }
             });
         },
-        
+
         // Remove the scrollbar (and the generated HTML elements).
         //
         // usage:
@@ -489,7 +491,7 @@ Changelog:
             this.setHandlePosition();
             this.setContentPosition();
         },
-        
+
         //
         // Remove scrollbar dom elements
         //


### PR DESCRIPTION
This error raises when i use scrollto on div without overflowing content. 
Light fix for prevent this error :)
