### PR TITLE
Adjust for dynamically changed container size.

### DIFF
--- a/jquery.scroll.js
+++ b/jquery.scroll.js
@@ -125,9 +125,9 @@ Changelog:
                 props.contentHeight = $.fn.scrollbar.contentHeight(container);
 
                 // if the content height is lower than the container height, do nothing and return.
-                if(props.contentHeight <= props.containerHeight){
-                    return true;
-                }
+                //if(props.contentHeight <= props.containerHeight){
+                    //return true;
+                //}
 
                 // create a new scrollbar object and append to DOM node for later use
                 this.scrollbar = new $.fn.scrollbar.Scrollbar(container, props, options);
@@ -139,11 +139,13 @@ Changelog:
                 if(typeof fn === "function"){
                     fn(container.find(".scrollbar-pane"), this.scrollbar);
                 }
+
+				this.scrollbar.repaint();
             });
         },
 
 
-        // repaint the height and position of the scroll handle
+	// repaint the height and position of the scroll handle
         //
         // this method must be called in case content is added or reoved from the container.
         //
@@ -467,6 +469,8 @@ Changelog:
 		// update the height of the handleContainer
 		//
         setHandleContainerSize: function() {
+			var deltaY = this.props.containerHeight - this.container.height();
+
             this.props.containerHeight = this.container.height();
 
 			// hide the scroller if the content height is lower than the
@@ -486,6 +490,11 @@ Changelog:
                 'top':      this.handleArrowUp.outerHeight(true),
                 'height':   (this.props.containerHeight - this.handleArrowUp.outerHeight(true) - this.handleArrowDown.outerHeight(true)) + 'px'
             });
+
+			// Scroll up content as container gets bigger.
+			this.handle.top -= deltaY;
+			this.setHandlePosition();
+			this.setContentPosition();
 		},
 
 

--- a/jquery.scroll.js
+++ b/jquery.scroll.js
@@ -458,8 +458,22 @@ Changelog:
         // repaint scrollbar height and position
         //
         repaint: function(){
+            this.setHandleContainerSize();
             this.setHandle();
             this.setHandlePosition();
+        },
+
+        //
+        // update the height of the handleContainer
+        //
+        setHandleContainerSize: function() {
+            this.props.containerHeight = this.container.height();
+
+            this.handleContainer.css({
+                'position': 'absolute',
+                'top':      this.handleArrowUp.outerHeight(true),
+                'height':   (this.props.containerHeight - this.handleArrowUp.outerHeight(true) - this.handleArrowDown.outerHeight(true)) + 'px'
+            });
         },
 
 

--- a/jquery.scroll.js
+++ b/jquery.scroll.js
@@ -458,23 +458,35 @@ Changelog:
         // repaint scrollbar height and position
         //
         repaint: function(){
-            this.setHandleContainerSize();
+			this.setHandleContainerSize();
             this.setHandle();
             this.setHandlePosition();
         },
 
-        //
-        // update the height of the handleContainer
-        //
+		//
+		// update the height of the handleContainer
+		//
         setHandleContainerSize: function() {
             this.props.containerHeight = this.container.height();
+
+			// hide the scroller if the content height is lower than the
+			// container height
+			if(this.props.contentHeight <= this.props.containerHeight) {
+            	this.handleContainer.hide();
+				this.handleArrowDown.hide();
+				this.handleArrowUp.hide();
+			} else {
+            	this.handleContainer.show();
+				this.handleArrowDown.show();
+				this.handleArrowUp.show();
+			}
 
             this.handleContainer.css({
                 'position': 'absolute',
                 'top':      this.handleArrowUp.outerHeight(true),
                 'height':   (this.props.containerHeight - this.handleArrowUp.outerHeight(true) - this.handleArrowDown.outerHeight(true)) + 'px'
             });
-        },
+		},
 
 
         //

--- a/jquery.scroll.js
+++ b/jquery.scroll.js
@@ -124,11 +124,6 @@ Changelog:
                 // save content height in properties
                 props.contentHeight = $.fn.scrollbar.contentHeight(container);
 
-                // if the content height is lower than the container height, do nothing and return.
-                //if(props.contentHeight <= props.containerHeight){
-                    //return true;
-                //}
-
                 // create a new scrollbar object and append to DOM node for later use
                 this.scrollbar = new $.fn.scrollbar.Scrollbar(container, props, options);
 


### PR DESCRIPTION
I added so that the height of the handle container is updated in the repaint method.

This makes sense if you programatically want to alter the size of your scrollable container after the fact.

EDIT: Made a few more changes to accommodate for a resized element:
1. As the element is resized to be bigger than the content, the scroller gets hidden.
2. If the user have scrolled down a bit, and then the element is resized so that the scroller is no longer needed, the  content should be scrolled up so that the entire content can be seen.
3. The scroller elements are always created, they are now hidden instead if the container is large enough for the entire content to be seen. The reason for this is that the scroller elements might be needed later if the container is made smaller.
